### PR TITLE
update: use https and www for site url

### DIFF
--- a/publishconf.py
+++ b/publishconf.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(os.curdir)
 from pelicanconf import *
 
-SITEURL = 'http://gzlug.org'
+SITEURL = 'https://www.gzlug.org'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
Per update of GitHub Pages, www.gzlug.org is enabled with HTTPS support. We should update the site setting so the generated files are using it.